### PR TITLE
Fixing Kraemer sampling

### DIFF
--- a/simsam/simsam.py
+++ b/simsam/simsam.py
@@ -65,10 +65,7 @@ def kraemer_sampling(n, N=1, full_support=True):
     .. [1] Noah A. Smith and Roy W. Tromble, "Sampling Uniformly from
     the Unit Simplex," 2004.
     """
-    if full_support:
-        M = sys.maxsize - n
-    else:
-        M = sys.maxsize
+    M = sys.maxsize
 
     P = []
 
@@ -76,20 +73,18 @@ def kraemer_sampling(n, N=1, full_support=True):
 
         rng = np.random.default_rng()
 
-        X = rng.choice(M - 1, replace=False, size=n - 1)
+        X = rng.choice(M - 1, replace=False, size=n - 1) + 1
         X = sorted(X)
         X = [0] + X + [M]
         Y = np.diff(X)
 
-        if full_support:
+        if not full_support:
             P.append(np.asarray(Y) / M)
         # Need to perform additional normalisation to ensure that zeroes
         # are allowed.
         else:
             Y = np.asarray(Y, dtype=float)
-            Y = (Y / M) * Y - 1.0
-            Y /= (sys.maxsize - n)
-
+            Y = (Y - 1) / (M - n)
             P.append(Y)
 
     return np.asarray(P)

--- a/simsam/simsam.py
+++ b/simsam/simsam.py
@@ -78,7 +78,7 @@ def kraemer_sampling(n, N=1, full_support=True):
         X = [0] + X + [M]
         Y = np.diff(X)
 
-        if not full_support:
+        if full_support:
             P.append(np.asarray(Y) / M)
         # Need to perform additional normalisation to ensure that zeroes
         # are allowed.

--- a/tests/test_simsam.py
+++ b/tests/test_simsam.py
@@ -4,13 +4,14 @@ from simsam import naive_sampling
 from simsam import kraemer_sampling
 
 from unittest import TestCase
+from functools import partial
 
 
 class SmokeTest(TestCase):
     """Simple smoke test to ensure that samples are valid."""
 
     def test(self):
-        for f in [naive_sampling, kraemer_sampling]:
+        for f in [naive_sampling, kraemer_sampling, partial(kraemer_sampling, full_support = False)]:
             P = f(10, 1000)
 
             for p in P:


### PR DESCRIPTION
There are some issues with the kraemer sampling function which this pull request seeks to rectify.

First of all there is an off by one error here:
https://github.com/Pseudomanifold/Simsam/blob/e89e9a6c6d87ca77d764e84f8c381b52ee0e504d/simsam/simsam.py#L79
according to the paper samples should be taken from [1, 2, ..., M - 1] this line currently samples from [0, 1, ..., M - 2]

~~This block here mixes up the cases of `full_support`:~~
https://github.com/Pseudomanifold/Simsam/blob/e89e9a6c6d87ca77d764e84f8c381b52ee0e504d/simsam/simsam.py#L84-L93
~~that is it performs the `full_support` normalization if the user has specified they don't want full support.~~
edit: woops I thought `full_support` meant the entire simplex is sampled. Re-read the docstring and reverted that change.

Finally the normalization here:
https://github.com/Pseudomanifold/Simsam/blob/e89e9a6c6d87ca77d764e84f8c381b52ee0e504d/simsam/simsam.py#L89-L91
does not result in a vector which sums to 1. 

This pull request adds a test case which makes sure that kraemer sampling passes the smoke test both with full support turned on and off (this test fails with the current implementation) and fixes the above bugs.